### PR TITLE
docs: fix inaccurate README and add missing --acp-enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,34 +8,37 @@ Amplifier Server provides the backend infrastructure for AI agent interactions:
 
 - **HTTP REST API** for session management
 - **Server-Sent Events (SSE)** for real-time streaming
+- **WebSocket** for full-duplex communication
 - **stdio transport** for embedded/CLI use
 - **Protocol layer** with Command/Event types for client interoperability
 - **SDK** for both remote and embedded (in-process) modes
+- **Agent Client Protocol (ACP)** support for editor integrations
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Client Applications                          │
-│  (amplifier-tui, web apps, IDE extensions, etc.)                │
-└─────────────────────────────────┬───────────────────────────────┘
-                                  │
-                    SDK (HTTP or Embedded)
-                                  │
-┌─────────────────────────────────┴───────────────────────────────┐
-│                    Amplifier Server                             │
-├─────────────────────────────────────────────────────────────────┤
-│  Protocol Layer                                                 │
-│  ├── Commands (session.create, prompt.send, etc.)               │
-│  └── Events (result, error, content.delta, etc.)                │
-├─────────────────────────────────────────────────────────────────┤
-│  Transport Layer                                                │
-│  ├── HTTP + SSE (primary)                                       │
-│  └── stdio (for embedded/subprocess use)                        │
-├─────────────────────────────────────────────────────────────────┤
-│  Session Manager                                                │
-│  └── Manages Amplifier sessions (or mock mode without core)     │
-└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Client Applications                              │
+│  (amplifier-tui, web apps, IDE extensions, etc.)                    │
+└─────────────────────────────────────────────────┬───────────────────┘
+                                                  │
+                        SDK (HTTP, WebSocket, or Embedded)
+                                                  │
+┌─────────────────────────────────────────────────┴───────────────────┐
+│                    Amplifier Server                                 │
+├─────────────────────────────────────────────────────────────────────┤
+│  Protocol Layer                                                     │
+│  ├── Commands (session.create, prompt.send, approval.respond, etc.) │
+│  └── Events (result, error, content.delta, tool.call, etc.)         │
+├─────────────────────────────────────────────────────────────────────┤
+│  Transport Layer                                                    │
+│  ├── HTTP + SSE (primary)                                           │
+│  ├── WebSocket (full-duplex)                                        │
+│  └── stdio (for embedded/subprocess use)                            │
+├─────────────────────────────────────────────────────────────────────┤
+│  Session Manager                                                    │
+│  └── Manages Amplifier sessions with persistence                    │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Installation
@@ -64,6 +67,80 @@ amplifier-server serve --reload
 
 # Enable Agent Client Protocol (ACP) endpoints
 amplifier-server serve --acp-enabled
+```
+
+### One-Shot Execution
+
+```bash
+# Execute a prompt and exit
+amplifier-server run "What is 2+2?"
+
+# With specific bundle
+amplifier-server run "Analyze this code" --bundle foundation
+
+# Continue existing session
+amplifier-server run "And what about 3+3?" --session sess_abc123
+
+# JSON output for scripting
+amplifier-server run "List files" --json
+```
+
+### Session Management
+
+```bash
+# List saved sessions
+amplifier-server session list
+
+# Include agent sub-sessions
+amplifier-server session list --all
+
+# Show session details
+amplifier-server session info sess_abc123
+
+# Include transcript
+amplifier-server session info sess_abc123 --transcript
+
+# Resume a session
+amplifier-server session resume sess_abc123
+
+# Resume and continue conversation
+amplifier-server session resume sess_abc123 "What else can you tell me?"
+
+# Delete a session
+amplifier-server session delete sess_abc123
+
+# Clear all sessions
+amplifier-server session clear --yes
+```
+
+### Bundle Management
+
+```bash
+# List available bundles
+amplifier-server bundle list
+
+# Show bundle information
+amplifier-server bundle info foundation
+```
+
+### Provider Management
+
+```bash
+# List available providers
+amplifier-server provider list
+
+# Check if a provider is configured
+amplifier-server provider check anthropic
+```
+
+### Configuration
+
+```bash
+# Show current configuration
+amplifier-server config
+
+# JSON output
+amplifier-server config --json
 ```
 
 ### Agent Client Protocol (ACP)
@@ -155,13 +232,34 @@ client = create_client("http://localhost:4096")
 client = create_embedded_client()
 
 # Create session
-session = await client.create_session(bundle="my-bundle")
+session = await client.session.create(title="my-session")
 
-# Send prompt and stream events
-async for event in client.prompt(session.session_id, "Hello!"):
+# List sessions
+sessions = await client.session.list()
+
+# Get session by ID
+session = await client.session.get(session_id)
+
+# Send prompt
+result = await client.session.prompt(
+    session_id=session.session_id,
+    parts=[MessagePart(type="text", text="Hello!")]
+)
+
+# Abort session
+await client.session.abort(session_id)
+
+# Delete session
+await client.session.delete(session_id)
+
+# Subscribe to event stream
+async for event in client.event.subscribe():
     print(f"Event: {event.type}")
-    if event.final:
+    if event.type == "session.idle":
         break
+
+# Close client
+await client.close()
 ```
 
 ## Protocol
@@ -180,6 +278,7 @@ The server uses a Command/Event protocol for all communication:
 | `session.delete` | Delete session |
 | `prompt.send` | Send prompt, streams events |
 | `prompt.cancel` | Cancel running prompt |
+| `approval.respond` | Respond to an approval request |
 
 ### Events (Server → Client)
 
@@ -190,18 +289,35 @@ The server uses a Command/Event protocol for all communication:
 | `result` | Command completed successfully |
 | `error` | Command failed |
 | `ack` | Command received, processing |
-| `content.delta` | Streaming content chunk |
-| `content.end` | Streaming complete |
-| `tool.call` | Tool invocation |
+| `stream.start` | Streaming started |
+| `stream.delta` | Streaming content chunk |
+| `stream.end` | Streaming complete |
+| `content.start` | Content block started |
+| `content.delta` | Content chunk (text) |
+| `content.end` | Content block complete |
+| `thinking.delta` | Reasoning/thinking chunk |
+| `thinking.end` | Reasoning complete |
+| `tool.call` | Tool invocation started |
 | `tool.result` | Tool completed |
+| `tool.error` | Tool execution failed |
+| `session.created` | Session was created |
+| `session.updated` | Session was updated |
+| `session.deleted` | Session was deleted |
+| `session.state` | Session state changed |
 | `approval.required` | User approval needed |
+| `approval.resolved` | Approval was handled |
+| `agent.spawned` | Sub-agent was spawned |
+| `agent.completed` | Sub-agent completed |
+| `notification` | Server notification |
+| `heartbeat` | Connection heartbeat |
 
 ### Event Correlation
 
 All events include:
 - `id` - Unique event ID
-- `correlation_id` - Links to originating command
+- `correlation_id` - Links to originating command (optional for server-initiated events)
 - `timestamp` - ISO 8601 timestamp
+- `sequence` - Position in stream (for ordered events)
 - `final` - True if this is the last event for the command
 
 ## API Endpoints
@@ -212,11 +328,31 @@ All events include:
 |--------|------|-------------|
 | GET | `/health` | Health check |
 | GET | `/ping` | Ping/pong |
-| POST | `/session` | Create session |
 | GET | `/session` | List sessions |
+| POST | `/session` | Create session |
+| POST | `/session/cleanup` | Clean up old sessions (admin) |
 | GET | `/session/{id}` | Get session |
+| PATCH | `/session/{id}` | Update session |
 | DELETE | `/session/{id}` | Delete session |
 | POST | `/session/{id}/prompt` | Send prompt (SSE stream) |
+| POST | `/session/{id}/prompt/sync` | Send prompt (non-streaming) |
+| POST | `/session/{id}/abort` | Abort active session |
+| GET | `/session/{id}/state` | Get session state |
+| POST | `/session/{id}/approval` | Handle approval response |
+
+### WebSocket Endpoint
+
+| Path | Description |
+|------|-------------|
+| `/ws` | WebSocket for full-duplex communication |
+
+### ACP Endpoints (when enabled)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/acp/rpc` | JSON-RPC endpoint |
+| GET | `/acp/events` | SSE event stream |
+| WS | `/acp/ws` | WebSocket endpoint |
 
 ### Streaming Formats
 
@@ -228,7 +364,7 @@ The `/session/{id}/prompt` endpoint supports:
 
 ```bash
 # Install dev dependencies
-uv pip install -e ".[dev]"
+uv sync --group dev
 
 # Run tests
 pytest
@@ -248,18 +384,63 @@ ruff format src/
 
 ```
 src/amplifier_server_app/
-├── protocol/          # Command/Event types
-│   ├── commands.py    # Command definitions
-│   ├── events.py      # Event definitions
-│   └── handler.py     # Command processing
-├── transport/         # Transport implementations
-│   ├── base.py        # Abstract interfaces
-│   ├── sse.py         # SSE streaming
-│   └── stdio.py       # stdio for IPC
-├── routes/            # HTTP routes
-├── sdk/               # Client SDK
-├── session.py         # Session management
-└── app.py             # Starlette application
+├── __init__.py            # Package initialization
+├── app.py                 # Starlette application factory
+├── cli.py                 # CLI commands (serve, run, session, bundle, etc.)
+├── session.py             # Session management and lifecycle
+├── session_store.py       # Session persistence
+├── bundle_manager.py      # Bundle loading and management
+├── bus.py                 # Event bus for internal communication
+├── events.py              # Event handling
+├── event_types.py         # Event type definitions
+├── resolvers.py           # Configuration resolvers
+├── project_utils.py       # Project utilities
+├── acp/                   # Agent Client Protocol implementation
+│   ├── __init__.py
+│   ├── agent.py           # ACP agent adapter
+│   ├── routes.py          # ACP HTTP routes
+│   ├── transport.py       # ACP transport layer
+│   └── types.py           # ACP type definitions
+├── protocol/              # Command/Event protocol layer
+│   ├── __init__.py
+│   ├── commands.py        # Command definitions
+│   ├── events.py          # Event definitions
+│   └── handler.py         # Command processing
+├── protocols/             # Protocol implementations
+│   ├── __init__.py
+│   ├── approval.py        # Approval flow handling
+│   ├── display.py         # Display protocol
+│   ├── hooks.py           # Hook integration
+│   ├── spawn.py           # Agent spawning
+│   └── streaming.py       # Streaming protocol
+├── routes/                # HTTP route handlers
+│   ├── __init__.py
+│   ├── events.py          # SSE event routes
+│   ├── health.py          # Health check routes
+│   ├── protocol_adapter.py # Protocol-to-HTTP adapter
+│   ├── session.py         # Session CRUD routes
+│   └── websocket.py       # WebSocket handler
+├── sdk/                   # Client SDK
+│   ├── __init__.py
+│   ├── client.py          # SDK client implementation
+│   └── types.py           # SDK type definitions
+└── transport/             # Transport implementations
+    ├── __init__.py
+    ├── base.py            # Abstract transport interface
+    ├── sse.py             # SSE streaming
+    ├── stdio.py           # stdio for IPC
+    ├── stdio_adapter.py   # stdio protocol adapter
+    └── websocket.py       # WebSocket transport
+
+docs/
+└── ACP.md                 # Agent Client Protocol documentation
+
+tests/
+├── conftest.py            # Test fixtures
+├── test_session_store.py  # Session store tests
+├── acp/                   # ACP tests
+├── integration/           # Integration tests
+└── unit/                  # Unit tests
 ```
 
 ## License

--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -50,21 +50,23 @@ pip install -e .
 
 ### HTTP Mode (Remote Agents)
 
-Start the server to expose ACP endpoints over HTTP:
+Start the server with ACP endpoints enabled using `--acp-enabled`:
 
 ```bash
-# Default port (4096)
-amplifier-server serve
+# Default port (4096) with ACP enabled
+amplifier-server serve --acp-enabled
 
 # Custom port
-amplifier-server serve --port 8080
+amplifier-server serve --acp-enabled --port 8080
 
-# Custom host and port
-amplifier-server serve --host 0.0.0.0 --port 8080
+# Custom host and port (e.g., for external access)
+amplifier-server serve --acp-enabled --host 0.0.0.0 --port 8080
 
 # Development mode with auto-reload
-amplifier-server serve --reload
+amplifier-server serve --acp-enabled --reload
 ```
+
+> **Note:** The `--acp-enabled` flag is required to expose ACP endpoints. Without it, only the core HTTP API is available.
 
 The server exposes these ACP endpoints:
 


### PR DESCRIPTION
## Summary

- **README.md**: Comprehensive update to accurately reflect the codebase
  - Fixed incomplete project structure (was missing ~20 files/directories including `acp/`, `protocols/`, `cli.py`, `bundle_manager.py`, `session_store.py`, etc.)
  - Fixed wrong SDK usage examples (`client.create_session()` → `client.session.create()`)
  - Added missing CLI commands (`run`, `session list/info/resume/delete/clear`, `bundle list/info`, `provider list/check`, `config`)
  - Added missing API endpoints (`prompt/sync`, `abort`, `state`, `approval`, `cleanup`, `PATCH session`, WebSocket)
  - Added missing event types (`stream.*`, `thinking.*`, `session.*`, `agent.*`, etc.)
  - Added WebSocket transport to overview

- **docs/ACP.md**: Fixed missing `--acp-enabled` flag
  - All server start examples now include `--acp-enabled` flag which is required to expose ACP endpoints
  - Added note explaining the flag is required

## Test plan

- [x] Verified project structure matches actual codebase
- [x] Verified SDK examples match actual API
- [x] Verified CLI commands exist and work as documented
- [x] Verified API endpoints match actual server implementation
- [x] Verified `--acp-enabled` flag is required for ACP functionality

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)